### PR TITLE
Fix some issues with compare_testfiles.sh on Ubuntu

### DIFF
--- a/tests/compare_testfiles.sh
+++ b/tests/compare_testfiles.sh
@@ -25,7 +25,7 @@ wctest()
 
 pythontest()
 {
-	OUT=`(time echo "print str(sum(1 for line in open('$1'))) + ' $1'" | python) 2>&1 | grep real | cut -f 2 | cut -c 3-`
+	OUT=`(time python -c "print str(sum(1 for line in open('$1'))) + ' $1'") 2>&1 | grep real | cut -f 2 | cut -c 3-`
 	echo "python: $1 $OUT"
 	return 0
 }

--- a/tests/compare_testfiles.sh
+++ b/tests/compare_testfiles.sh
@@ -9,7 +9,6 @@ fi
 
 tlctest()
 {
-	
 	OUT=`(time $TLC $1) 2>&1 | grep real | cut -f 2 | cut -c 3-`
 	echo "tlc: $1 $OUT"
 	return 0
@@ -36,7 +35,7 @@ tlctest test_1GB.txt
 tlctest test_10GB.txt
 
 echo Timing for 'python'
-pythontest test_10MB.txt 
+pythontest test_10MB.txt
 pythontest test_100MB.txt
 pythontest test_1GB.txt
 pythontest test_10GB.txt

--- a/tests/compare_testfiles.sh
+++ b/tests/compare_testfiles.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-if [ "$1" = "" ]; then 
+export TIME='real\t  %e'
+
+if [ "$1" = "" ]; then
 	echo "specify path to tlc binary"
 	exit 1
 else


### PR DESCRIPTION
compare_testfiles.sh seems to be quite system dependent
here (Ubuntu 21.04), the shell 'time' command doesn't work as expected:
(1) the output doesn't follow POSIX 1003.2, but rather I get 
0.00user 0.00system 0:00.00elapsed 94%CPU (0avgtext+0avgdata 2804maxresident)k
0inputs+0outputs (0major+124minor)pagefaults 0swaps
(2) shell 'time' measures the time to pipe to Python, not the execution itself, resulting in 0.00s runtime for Python

the fix explicitly specifies the TIME format used, and uses -c to pass code to Python (NB: python2 is assumed)